### PR TITLE
Updating README in light of directory reorganization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,263 +1,320 @@
-![Linux Build](https://github.com/ammarhakim/gkylzero/actions/workflows/main.yml/badge.svg)
-![Mac Build](https://github.com/ammarhakim/gkylzero/actions/workflows/osx-build.yml/badge.svg)
+![Mac Build](https://github.com/ammarhakim/gkeyll/actions/workflows/osx-build.yml/badge.svg)
 
 # About
 
-This is the GkeyllZero layer of the Gkeyll code. The name is
-pronounced as in the book "The Strange Case of Dr. Jekyll and
-Mr. Hyde" which is required reading for all members of the Gkeyll
-Team. GkeyllZero is written in C (and some C++ for GPUs).
-GkeyllZero is developed at the Princeton Plasma Physics Laboratory (PPPL)
-and is copyrighted 2020-2023 by Ammar Hakim and the Gkeyll Team.
+This is the main repository for `Gkeyll`: a multi-scale, multi-physics simulation
+framework developed for a variety of applications in plasma physics, space physics,
+general relativity, and high-energy astrophysics. The name is pronounced as in the book 
+"The Strange Case of Dr. Jekyll and Mr. Hyde" which is required reading for all
+members of the `Gkeyll` Team. The core of `Gkeyll` is written in C, featuring a
+lightweight, modular design and minimal external dependencies, plus an additional Lua
+scripting layer (for specifying simulation input parameters), with trace quantities of C++
+for GPU support. `Gkeyll` is developed and maintained at the Princeton Plasma Physics
+Laboratory (PPPL) and is copyrighted 2020-2025 by Ammar Hakim and the `Gkeyll` Team.
 
-**NOTE**: Though the code is called "Gkeyll" and "GkeyllZero" we use
-the prefix "gkyl" in the source code itself. This may be confusing at
-first but one gets used to it.
+**NOTE**: Though the framework is called `Gkeyll`, the abbreviation `gkyl` is used
+commonly within the code itself.
 
 Documentation is available at http://gkeyll.rtfd.io.
 
+# Code structure
+
+`Gkeyll` is designed around a fully modular architecture, with the entire code being
+built hierarchically, with the following layers:
+
+* `core`: essential infrastructure (grid-generation, parallelism, file input/output, Lua
+  tools, array operations, fundamental discontinuous Galerkin operations, etc.)
+* `moments`: finite-volume solvers for hyperbolic PDE systems, including (relativistic)
+  multi-fluid equations, Maxwell's equations, Einstein's equations, etc., plus
+  infrastructure for specifying curved spacetime geometries (e.g. for black holes and 
+  neutron stars)
+* `vlasov`: modal discontinous Galerkin solvers for Vlasov-Maxwell and Vlasov-Poisson
+  systems, as well as general Hamiltonian systems via their canonical Poisson bracket
+  structure
+* `gyrokinetic`: modal discontinuous Galerkin solvers for the full-$f$, long-wavelength
+  gyrokinetic equation coupled to the gyrokinetic Poisson equation, plus infrastructure 
+  for specifying tokamak and mirror geometries
+* `pkpm`: modal discontinuous Galerkin solvers for the
+  Parallel-Kinetic-Perpendicular-Moment system
+
+Although `Gkeyll` as a whole comprises all of these layers, each layer can be built
+individually, with dependencies only upon the layer below it (e.g. `moments` depends
+only on `core`, `vlasov` depends only upon `moments`, etc.).
+
 # Installation
 
-Installing GkeyllZero consists of three steps: building dependencies,
-configuring, and compiling. How you do the first two of these steps varies
-depending on whether you are installing on a computer we already have
-installation scripts ("machine files") for, or if you are installing in
-a new computer. Since the former is the most common we describe that first.
+Installing `Gkeyll` consists of three steps: building dependencies, configuring, and
+compiling. How you do the first two of these steps varies depending upon whether you are
+installing on a supercomputer or operating system for which we already have installation
+scripts (i.e. "machine files"), or you are installing on an entirely new supercomputer or
+operating system. Since the former is the most common, we describe that first.
 
-## On a known computer using machine files
+## On a known operating system or supercomputer, using machine files
 
-We provide a set of "machine files" to ease the build process.
-These are stored in the machines directory. For example, to
-build on Traverse please run
+We provide a set of "machine files" to ease the build process. These are stored in the
+`/machines` directory. For example, to build on macOS, you simply run:
+
+```
+./machines/mkdeps.macos.sh
+./machines/configure.macos.sh
+```
+
+whereas to build on the Traverse supercomputer, you simply run:
+
 ```
 ./machines/mkdeps.traverse.sh
 ./machines/configure.traverse.sh
 ```
-At this point you may need to manually load environment modules by hand
-if you haven't done it yet; for example on Traverse and Stellar-amd you
-need to ```module load cudatoolkit/11.6``` before proceeding. Next,
-compile the code with:
-```
-make -j # install
-```
-where # is the number of cores you wish to use (if working on the login
-node of a cluster it is preferable that you use fewer than the total number
-of cores available, otherwise you will slow down the login node and irk
-other users and admins).
 
-The ```machine``` files default to installing in $HOME/gkylsoft/, and to
-searching for dependencies there too. If you wish to install somewhere else
-you'll need to indicate the install directory in ```--prefix``` in both
-machine files, and make sure the paths to the dependencies are correct
-in the ```machines/configure.<machine name>.sh``` file.
+At this point, if you are building on a supercomputer/cluster (i.e. not on a personal
+computer), you may need to load certain environment modules manually. The requisite
+environment modules can be found at the top of the corresponding
+`/machines/configure.<machine name>.sh` file for that computer. For example, for
+Stellar-AMD, we see from the top of the `/machines/configure.stellar-amd.sh` configure
+script that we must run:
+
+```
+module load cudatoolkit/12.4
+module load openmpi/cuda-11.1/gcc/4.1.1
+```
+
+before proceeding. Next, simply compile the code with:
+
+```
+make install -j #
+```
+
+where # is the number of cores you wish to use for compilation (if working on the login
+node of a cluster, it may be diplomatic to use fewer than the total number of cores
+available, in the interests of preserving friendly relations with the cluster admins and
+other users).
+
+All of the `/machines` files default to installing dependencies in the `$HOME/gkylsoft/`
+directory, and to searching for dependencies there too. If you wish to install somewhere
+else, you'll need to indicate the desired installation directory using the `--prefix=`
+flag in both the `/machines/mkdeps.<machine name>.sh` and
+`/machines/configure.<machine name>.sh` machine files, and also ensure that the paths to
+each dependency are correct in the latter file.
 
 ## On a new computer (no machine files available)
 
-When installing on your own computer, or on a cluster we don't yet have
-machine files for, you could choose to build machine files using existing
-ones as guides, or you could do each step manually. We expand on each of
-these steps below.
+When installing on a new operating system or cluster that we don't yet have machine files
+for, you could choose to build machine files using existing ones as guides, or you could do
+each step manually. We expand on each of these steps below.
 
 ### Specifying/building dependencies
 
-GkeyllZero has a few dependencies (e.g. OpenBLAS, SuperLU, MPI (optional)).
-If you are on a cluster some or all of these libraries are likely already
-installed. To install dependencies (either all or the ones your cluster
-doesn't have) use the ```mkdeps.sh``` script in ```install-deps``` as
+`Gkeyll` has a few dependencies (e.g. OpenBLAS and SuperLU, optionally MPI, CUDA, and
+NCCL, etc.). If you are working on a cluster, some or all of these libraries are likely
+already installed. To install dependencies (either all of them, or only the ones your
+cluster doesn't have), use the `mkdeps.sh` script in the `/install-deps` directory, as
 follows:
+
 ```
 cd install-deps
 ./mkdeps.sh --build-openblas=yes --build-superlu=yes
 ```
-In this example we opted to build OpenBLAS and SuperLU, assuming
-neither is available in this new computer. This will install OpenBLAS and
-SuperLU in the ```$HOME/gkylsoft``` directory; in order to install in a
-different directory one must specify it with ``--prefix=``.
 
-Note that OpenBLAS **requires you to have gfortran**
-installed. Likewise, SuperLU **requires you to have cmake** installed.
-**You** are responsible for installing this on your machine. Also keep
-in mind that on Apple Macs you do not need to do anything special to use
-LAPACK/BLAS as it comes with the developer tools.
+In this example we opted to build OpenBLAS and SuperLU, assuming that neither is available
+on this new computer. This will install OpenBLAS and SuperLU in the ```$HOME/gkylsoft```
+directory; in order to install in a different directory one must specify it with the
+`--prefix=` flag.
 
-At this step, you can download ADAS data for neutral interactions by adding
-the flag ```--use-adas=yes``` after the other dependencies to be
-installed.
+Note that OpenBLAS **requires you to have gfortran** installed. Likewise, SuperLU
+**requires you to have cmake** installed. **You** are responsible for installing this on
+your machine. Also keep in mind that, on macOS, you should not need to do anything special
+to use LAPACK/BLAS, as these come pre-packaged as part of the Apple developer tools.
+
+At this stage, you can also download ADAS data for neutral interactions (useful for some
+gyrokinetic simulations) by adding the flag ```--use-adas=yes``` after the other
+dependencies to be installed.
 
 ### Configuring
 
-The (optional) configure step is used when we need to specify the use of
-specific compilers, dependency paths or other options. For example, if
-a dependency is already available in your computer/cluster, you should
-use the configure script to specify the location of the include and full
-path to the static libraries for these dependencies. See configure help.
+The (optional) configuration step is used when we need to specify the use of specific
+compilers, dependency paths, or other options. For example, if a dependency is already
+available in your computer/cluster, you should use the configure script to specify the
+location of the include, and the full path to the static libraries, for these
+dependencies. Run:
+
 ```
 ./configure --help
 ```
-You can also see machine files in ```machines/``` for examples of how
-this script is used.
 
+for more details. You can also see machine files in ```machines/``` for examples of how
+this script is used.
 
 ### Compiling
 
-Once you are done with installing/specifying the compiler and
-dependencies simply type:
+Once you are done with installing/specifying the compiler and dependencies, simply type:
+
 ```
  make -j #
 ```
-in the top-level directory (# is the number of cores, see previous
-comment on this).
 
-If you do not run configure (see previous section/step) you can also
-specify the compiler when running make. For example:
+in the top-level directory (# is the number of cores; see previous comment on this).
+
+If you do not run configure (see previous section/step) you can also specify the compiler
+when running make. For example:
+
 ```
  make CC=icc -j #
 ```
-to build with the Intel C compiler (# is the number of cores, see previous
-comment on this). If you use the NVIDIA nvcc compiler then the CUDA
-specific parts of the code will be built:
+
+to build with the Intel C compiler (# is the number of cores; see previous comment on
+this). If you use the NVIDIA `nvcc` compiler, then the CUDA specific parts of the code
+will be built:
+
 ```
 make CC=nvcc -j #
 ```
-(# is the number of cores, see previous comment on this).
 
-If you want to use the code as a library (e.g. for use by
-[gkyl](https://github.com/ammarhakim/gkyl/)) you should install it:
+(# is the number of cores; see previous comment on this).
+
+On the other hand, if you do not wish to compile the entire `Gkeyll` system, but only
+one specific layer (e.g. `moments`), just type:
+
 ```
-make install
-```
-or run compilation and library installation in one step as
-```
-make -j # install
+make moments -j #
 ```
 
-Note that GkeyllZero is meant to be used as a *library*. You can use
-it to create your own "app" for your particular problem. See that
-various "app_*.c" files for examples. Full documentation is available
-on the RTFD website linked above.
+or its equivalent. To compile the `Gkeyll` executable itself (e.g. to run Lua simulation
+files), simply type:
 
-In order to test that your installation worked, you can compile one of
-the unit or regression tests and run it. See instructions for that below.
+```
+make gkeyll -j #
+```
 
-# Developing for GkeyllZero
+If in doubt, just run:
+
+```
+make everything -j #
+```
+
+to build every part of the `Gkeyll` system (including `Gkeyll` executable, and all unit
+and regression tests).
+
+Whatever you choose, in order to test that your installation worked, you can compile one
+of the unit or regression tests and run it. See instructions for that below.
+
+# Developing for `Gkeyll`
 
 Built-in tests
 --------------
 
-GkeyllZero has built in unit (```/unit```) and regression (```/regression```) tests
-that run automatically by our CI system or can be run manually by
-developers. These tests are not compiled by the simple ```make```
-command used to compile the code (see previous sections). Instead the
-developer needs to build specific targets. For example we can build
-the unit tests for gkyl_array on a CPU with
-```
-make build/unit/ctest_array
-```
-or build the same unit test on a NVIDIA GPU-accelerated node with
-```
-make cuda-build/unit/ctest_array
-```
-These produce an executable in the ```build``` or ```cuda-build``` directory,
-respectively, that can be run. For example, to run the ```ctest_array``` executable
-we just compiled use
-```
-./cuda-build/unit/ctest_array
-```
-Alternatively you could choose to build all unit tests with
-```
-make -j # unit
-```
-(# is the number of cores, see previous comment on this). A similar procedure
-should be followed to compile and run regression tests in ```/regression```.
-Regression test executables have a number of run-time options which you can list
-with the `-h` flag, i.e. ```<executable> -h```.
+`Gkeyll` has built-in unit tests (for testing individual units of functionality) and
+regression tests (for testing full-scale simulations, either from C or from Lua) that are
+run automatically by our CI system, but can also be run manually by developers. These
+tests are not compiled by the default `make` command used to compile the code (see
+previous sections), but can be compiled by building specific targets. For example, to
+build the `ctest_array` unit test in the `/core` directory, run:
 
-You may also compile and run all the unit tests with one command:
 ```
-make -j # check
+make build/core/unit/ctest_array
 ```
 
-If you wish to run a regression test from a different directory (e.g. scratch
-in a cluster), copy the ```Makefile``` in the ```$HOME/gkylsoft/share``` directory
-to your desired directory, change ```rt_twostream``` for the name of your test
-there in (best to use search & replace), and run the makefile with ```make -j #```,
-where ```#``` is a responsibly chosen number of cores.
+or, to build the same unit test on an NVIDIA GPU-accelerated node:
 
-Automatic regression testing
-----------------------------
+```
+make cuda-build/core/unit/ctest_array
+```
 
-There is also an automatic regression testing system implemented within GkeyllZero,
-included as part of our larger automatic CI framework, which can be built in serial
-(for instance, for the gyrokinetics system) with:
+These produce an executable in the `/build` or `/cuda-build` directories,
+respectively, which can then be run directly. For example, to run the `ctest_array`
+executable we just compiled, use:
+
 ```
-make build/ci/gk_regression
+./build/core/unit/ctest_array
 ```
-or, in parallel, with:
+
+or
+
 ```
-make build/ci/gk_regression_parallel
+./cuda-build/core/unit/ctest_array
 ```
-and then run with:
+
+Alternatively you could choose to build all unit tests with:
+
 ```
-./build/ci/gk_regression
+make unit -j #
 ```
-or:
+
+or all unit tests for a specific layer (e.g. `moments`) with:
+
 ```
-./build/ci/gk_regression_parallel
+make moments-unit -j #
 ```
-or (for instance, for the moment app) with:
+
+(# is the number of cores; see previous comment on this). A similar procedure
+should be followed to compile and run C regression tests in `/<layer>/creg`, e.g. to
+build the `rt_10m_gem` C regression test in the `/moments` directory, run:
+
 ```
-make build/ci/moment_regression
+make build/moments/creg/rt_10m_gem
 ```
-or, in parallel, with (note that the parallel regression system requires you to have
-built GkeyllZero using CUDA and MPI):
+
+or
+
 ```
-make cuda-build/ci/moment_regression_parallel
+make cuda-build/moments/creg/rt_10m_gem
 ```
-and then run with either:
+
+followed by:
+
 ```
-./build/ci/moment_regression
+./build/moments/creg/rt_10m_gem
 ```
-or:
+
+or
+
 ```
-./cuda-build/ci/moment_regression_parallel
+./cuda-build/moments/creg/rt_10m_gem
 ```
-as necessary. By default, running the automatic regression testing system
-presents the user with an interactive list of numerical options (1 to run the
-full regression suite, 2 to view all regression results, 3 to run a specific
-regression test, 4 to view a specific regression result, 5 to (re)generate
-all accepted results, and 6 to (re)generate a specific accepted result).
-However, these options can also be passed in as command line arguments, so that:
+
+Regression test executables have a number of run-time options which you can list with the
+`-h` flag, i.e. ```<executable> -h```. Likewise, you can also compile all C regression
+tests with:
+
 ```
-./build/ci/gk_regression 3 4
-./build/ci/moment_regression 3 4
+make regression -j #
 ```
-will specifically run regression test number 4 in serial, with no additional
-interaction required from the user. The complete automatic CI framework can be
-built in a single step using:
+
+or all C regression tests for a specific layer (e.g. `moments`) with:
+
 ```
-make ci
+make moments-regression -j #
+```
+
+You may also compile *and run* all the unit tests with a single command:
+
+```
+make check -j #
+```
+
+or, for a specific layer (e.g. `moments`):
+
+```
+make moments-check -j #
 ```
 
 Development philosophy
 ---------------------
 
-Out goal is to keep GkeyllZero as simple and dependency free as
-possible. Some dependencies are unavoidable like MPI and linear
-algebra libraries. However, we must avoid an exponentially increasing
-dependency chain. Another goal is that GkeyllZero itself should be
-pure modern (C99/C11) C. Some parts of the code need C++ (nvcc is a
-C++ compiler for CUDA) but the core code itself should be in C.
+Out goal is to keep `Gkeyll` as simple and dependency-free as possible. Some dependencies
+are unavoidable, like MPI and linear algebra libraries. However, we must avoid an
+exponentially increasing dependency chain. Another goal is that `Gkeyll` itself should be
+written in pure, modern (C99/C11) C. Some parts of the code need C++ (since `nvcc` is a C++
+compiler for CUDA), but the core code itself should be in C.
 
-Developing in C (and C++) requires very strong focus and
-discipline. **Please consult** https://en.cppreference.com/w/ for
-standards documentation for these languages and their
-libraries. **Please use valgrind** to make sure all code is "valgrind
-clean". Pay attention to all compiler warnings.
+Developing in C (and C++) requires very strong focus and discipline. **Please consult**
+https://en.cppreference.com/w/ for standards documentation for these languages and their
+libraries. **Please use valgrind** to make sure all code is "valgrind clean". Pay
+attention to all compiler warnings.
 
-Most importantly, **please internalize and follow** the programming
-philosophy outlined in the document ["A Minimalist Approach to
-Software"](https://www.ammar-hakim.org/sj/pn/pn0/pn0-minimalism.html).
+Most importantly, **please internalize and follow** the programming philosophy outlined in
+the document
+["A Minimalist Approach to Software"](https://www.ammar-hakim.org/sj/pn/pn0/pn0-minimalism.html).
 
-When contributing code to the project, we suggest using a template 
-in our documentation to promote adherence to our community standards.
+When contributing code to the project, we suggest using a template in our documentation to 
+promote adherence to our community standards.
 [Suggested templates](https://gkeyll.readthedocs.io/en/latest/dev/suggested-templates.html).


### PR DESCRIPTION
Updating README to reflect the recent directory reorganization and renaming of the gkylzero repository, as well as to fix various other bits of documentation rot. This will all be heavily restructured in the near future, following our forthcoming documentation refresh, so these changes are simply intended to hold us steady until then.