### PR TITLE
Fixing problem with "make check" + relative file paths

### DIFF
--- a/core/Makefile-core
+++ b/core/Makefile-core
@@ -144,7 +144,7 @@ endif
 .PHONY: check valcheck
 # Run all unit tests
 check: unit ## Build (if needed) and run all unit tests
-	$(foreach unit,${UNITS},echo $(unit); $(unit) -E;)
+	$(foreach unit,${UNITS},echo $(unit); cd ../; ./core/$(unit) -E; cd core;)
 
 valcheck: unit ## Run valgrind on unit test
 	$(foreach unit,$(UNITS),valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes --show-error-list=yes $(unit) --exec=never 2>$(unit)_val_err 1>/dev/null;)

--- a/gyrokinetic/Makefile-gyrokinetic
+++ b/gyrokinetic/Makefile-gyrokinetic
@@ -189,7 +189,7 @@ endif
 .PHONY: check valcheck
 # Run all unit tests
 check: unit ## Build (if needed) and run all unit tests
-	$(foreach unit,${UNITS},echo $(unit); $(unit) -E;)
+	$(foreach unit,${UNITS},echo $(unit); cd ../; ./gyrokinetic/$(unit) -E; cd gyrokinetic;)
 
 valcheck: unit ## Run valgrind on unit test
 	$(foreach unit,$(UNITS),valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes --show-error-list=yes $(unit) --exec=never 2>$(unit)_val_err 1>/dev/null;)

--- a/moments/Makefile-moments
+++ b/moments/Makefile-moments
@@ -124,7 +124,7 @@ endif
 .PHONY: check valcheck
 # Run all unit tests
 check: unit ## Build (if needed) and run all unit tests
-	$(foreach unit,${UNITS},echo $(unit); $(unit) -E;)
+	$(foreach unit,${UNITS},echo $(unit); cd ../; ./moments/$(unit) -E; cd moments;)
 
 valcheck: unit ## Run valgrind on unit test
 	$(foreach unit,$(UNITS),valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes --show-error-list=yes $(unit) --exec=never 2>$(unit)_val_err 1>/dev/null;)

--- a/pkpm/Makefile-pkpm
+++ b/pkpm/Makefile-pkpm
@@ -116,7 +116,7 @@ endif
 .PHONY: check valcheck
 # Run all unit tests
 check: unit ## Build (if needed) and run all unit tests
-	$(foreach unit,${UNITS},echo $(unit); $(unit) -E;)
+	$(foreach unit,${UNITS},echo $(unit); cd ../; ./pkpm/$(unit) -E; cd pkpm;)
 
 valcheck: unit ## Run valgrind on unit test
 	$(foreach unit,$(UNITS),valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes --show-error-list=yes $(unit) --exec=never 2>$(unit)_val_err 1>/dev/null;)

--- a/vlasov/Makefile-vlasov
+++ b/vlasov/Makefile-vlasov
@@ -168,7 +168,7 @@ endif
 .PHONY: check valcheck
 # Run all unit tests
 check: unit ## Build (if needed) and run all unit tests
-	$(foreach unit,${UNITS},echo $(unit); $(unit) -E;)
+	$(foreach unit,${UNITS},echo $(unit); cd ../; ./vlasov/$(unit) -E; cd vlasov;)
 
 valcheck: unit ## Run valgrind on unit test
 	$(foreach unit,$(UNITS),valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes --show-error-list=yes $(unit) --exec=never 2>$(unit)_val_err 1>/dev/null;)


### PR DESCRIPTION
@Maxwell-Rosen pointed out an issue wherein running, e.g. `make core-check` was causing certain unit tests to segfault, even though they were running just fine individually. This was due to the fact that our outermost Makefile was running `cd core` (or an equivalent command) before calling `make check` in the interior Makefile, which was screwing up any tests that used relative file paths, since these all assume that one is running the test from the outermost directory.

I have made a small modification to the recursive Makefile structure to circumvent this problem by first navigating to the top-level directory, then running the unit test, and then navigating back, each time a `make check` is called.