### PR TITLE
Move ADAS download back to mkdeps, but now the option is --build-adas.

### DIFF
--- a/gyrokinetic/Makefile-gyrokinetic
+++ b/gyrokinetic/Makefile-gyrokinetic
@@ -73,19 +73,6 @@ regression: ${LLIB} ${SLLIB} ${REGS} creg/rt_arg_parse.h ## Build regression tes
 .PHONY: all
 all: $(LLIB) $(SLLIB) ## Build all targets
 	${MKDIR_P} ${INSTALL_PREFIX}/${PROJ_NAME}/share/adas
-	@if [ -z "$$(ls ${INSTALL_PREFIX}/${PROJ_NAME}/share/adas/*.npy 2>/dev/null)" ]; then \
-		(cd data/adas && \
-		if ! python -c "import requests" &>/dev/null; then \
-			pip install requests; \
-		fi && \
-		if ! python -c "import numpy" &>/dev/null; then \
-			pip install numpy; \
-		fi && \
-		python download_adas.py && \
-		python adas_to_numpy.py && \
-		rm *.dat && \
-		mv *.npy ${INSTALL_PREFIX}/${PROJ_NAME}/share/adas/.); \
-	fi
 	cp ./data/adas/radiation_fit_parameters.txt ${INSTALL_PREFIX}/${PROJ_NAME}/share/adas
 .DEFAULT_GOAL := all
 

--- a/gyrokinetic/data/adas/process_adas.py
+++ b/gyrokinetic/data/adas/process_adas.py
@@ -1,0 +1,139 @@
+import urllib.request
+import urllib.error
+import os
+import numpy
+
+adas_data_dir = "."
+
+ADAS_FILES = {
+    "H":  {"acd": "acd12_h.dat",  "scd": "scd12_h.dat",  "plt": "plt12_h.dat",  "prb": "prb12_h.dat", "zmax": 1},
+    "He": {"acd": "acd96_he.dat", "scd": "scd96_he.dat", "plt": "plt96_he.dat", "prb": "prb96_he.dat", "zmax": 2},
+    "Li": {"acd": "acd96_li.dat", "scd": "scd96_li.dat", "plt": "plt96_li.dat", "prb": "prb96_li.dat", "zmax": 3},
+    "Be": {"acd": "acd96_be.dat", "scd": "scd96_be.dat", "plt": "plt96_be.dat", "prb": "prb96_be.dat", "zmax": 4},
+    "B":  {"acd": "acd89_b.dat",  "scd": "scd89_b.dat",  "plt": "plt89_b.dat",  "prb": "prb89_b.dat",  "zmax": 5},
+    "C":  {"acd": "acd96_c.dat",  "scd": "scd96_c.dat",  "plt": "plt96_c.dat",  "prb": "prb96_n.dat",  "zmax": 6},
+    "N":  {"acd": "acd96_n.dat",  "scd": "scd96_n.dat",  "plt": "plt96_n.dat",  "prb": "prb96_n.dat",  "zmax": 7},
+    "O":  {"acd": "acd96_o.dat",  "scd": "scd96_o.dat",  "plt": "plt96_o.dat",  "prb": "prb96_o.dat",  "zmax": 8},
+    "Ar": {"acd": "acd89_ar.dat", "scd": "scd89_ar.dat", "plt": "plt89_ar.dat", "prb": "prb89_ar.dat", "zmax": 18}
+}
+
+def fetch_file_urllib(filename, loc):
+    base_url = "https://open.adas.ac.uk/download/adf11"
+    filename_mod = filename.split("_")[0] + "/" + filename
+    full_url = f"{base_url}/{filename_mod}"
+    try:
+        with urllib.request.urlopen(full_url) as response:
+            if response.status != 200:
+                raise urllib.error.HTTPError(full_url, response.status, "Failed to download", response.headers, None)
+            content_bytes = response.read()
+        if len(content_bytes) < 1000:
+            raise ValueError(f'Could not fetch a valid file for {filename} from ADAS! Response was too short.')
+        with open(loc, "wb") as f:
+            f.write(content_bytes)
+    except Exception as e:
+        print(f"Error downloading {filename}: {e}")
+        raise
+
+def get_adas_file_loc(filename):
+    if filename == "none":
+        return
+    loc = os.path.join(adas_data_dir, filename)
+    if os.path.exists(loc):
+        return loc
+    fetch_file_urllib(filename, loc)
+    return loc
+
+class adas_adf11:
+    def __init__(self, filename):
+        self.filepath = os.path.join(adas_data_dir, filename)
+        self.filename = filename
+        self.file_type = self.filename[:3]
+        try:
+            self.imp = self.filename.split("_")[1].split(".")[0]
+        except Exception:
+            self.imp = None
+        self.load()
+        self.getClist()
+    def getClist(self):
+        self.clogNe = self.logNe.tolist()
+        self.clogT = self.logT.tolist()
+        self.clogdata = self.logdata.ravel().tolist()
+    def load(self):
+        loc = get_adas_file_loc(self.filename)
+        with open(loc) as f:
+            header = f.readline()
+            self.n_ion, self.n_ne, self.n_T = numpy.int_(header.split()[:3])
+            f.readline()
+            line = f.readline()
+            if all([a.isdigit() for a in line.split()]):
+                self.metastables = numpy.int_(line.split())
+                f.readline()
+                line = f.readline()
+            else:
+                self.metastables = numpy.ones(self.n_ion + 1, dtype=int)
+            logNe = []
+            while len(logNe) < self.n_ne:
+                logNe += [float(n) for n in line.split()]
+                line = f.readline()
+            logT = []
+            while len(logT) < self.n_T:
+                logT += [float(t) for t in line.split()]
+                line = f.readline()
+            subheader = line
+            ldata, self.Z, self.MGRD, self.MPRT = [], [], [], []
+            ind = 0
+            while True:
+                ind += 1
+                try:
+                    iprt, igrd, typ, z = subheader.split("/")[1:5]
+                    self.Z.append(int(z.split("=")[1]))
+                    self.MGRD.append(int(igrd.split("=")[1]))
+                    self.MPRT.append(int(iprt.split("=")[1]))
+                except Exception:
+                    self.Z.append(ind + 1)
+                    self.MGRD.append(1)
+                    self.MPRT.append(1)
+                drcofd = []
+                while len(drcofd) < self.n_ne * self.n_T:
+                    line = f.readline()
+                    drcofd += [float(L) for L in line.split()]
+                ldata.append(numpy.array(drcofd).reshape(self.n_T, self.n_ne))
+                subheader = f.readline().replace("-", " ")
+                if len(subheader) == 0 or subheader.isspace() or subheader[0] == "C":
+                    break
+        self.logNe = numpy.array(logNe)
+        self.logT = numpy.array(logT)
+        self.logdata = numpy.array(ldata)
+        self.meta_ind = list(zip(self.Z, self.MGRD, self.MPRT))
+    def data_for_charge_state(self, charge_state):
+        return self.logdata[int(charge_state), :, :]
+
+def write_files(adas_dict):
+    for name, props in adas_dict.items():
+        zmax = props["zmax"]
+        ioniz_np, recomb_np = [], []
+        for zi in range(zmax):
+            ioniz = adas_adf11(props["scd"])
+            ioniz_dat = ioniz.logdata[zi, :, :] - 6.0
+            ioniz_np.append(ioniz_dat.flatten())
+            recomb = adas_adf11(props["acd"])
+            recomb_dat = recomb.logdata[zi, :, :] - 6.0
+            recomb_np.append(recomb_dat.flatten())
+        ioniz_np = numpy.array(ioniz_np)
+        recomb_np = numpy.array(recomb_np)
+        ioniz_np.tofile(f"ioniz_{name.lower()}.npy")
+        recomb_np.tofile(f"recomb_{name.lower()}.npy")
+        ioniz.logT.tofile(f"logT_{name.lower()}.npy")
+        ioniz.logNe.tofile(f"logN_{name.lower()}.npy")
+
+def main():
+    # Download all ADAS files for supported elements
+    for element, files in ADAS_FILES.items():
+        print(f"Retrieving files for element {element}")
+        for key in ["acd", "scd", "plt", "prb"]:
+            get_adas_file_loc(files[key])
+    # Convert and write numpy arrays for all elements in the dictionary
+    write_files(ADAS_FILES)
+
+if __name__ == "__main__":
+    main()

--- a/install-deps/download-adas.sh
+++ b/install-deps/download-adas.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+source ./build-opts.sh
+
+# Install prefix
+PREFIX=$GKYLSOFT
+ADAS_DIR="$GKYLSOFT/gkeyll/share"
+
+mkdir -p $ADAS_DIR/adas
+#cd -
+python ../gyrokinetic/data/adas/download_adas.py
+echo "Converting ADAS data to numpy .."
+python ../gyrokinetic/data/adas/adas_to_numpy.py
+rm *.dat
+cp *.npy $ADAS_DIR/adas/.
+mv *.npy ../gyrokinetic/data/adas/.
+echo "ADAS data downloaded to $ADAS_DIR/adas"

--- a/install-deps/download-adas.sh
+++ b/install-deps/download-adas.sh
@@ -8,9 +8,7 @@ ADAS_DIR="$GKYLSOFT/gkeyll/share"
 
 mkdir -p $ADAS_DIR/adas
 #cd -
-python ../gyrokinetic/data/adas/download_adas.py
-echo "Converting ADAS data to numpy .."
-python ../gyrokinetic/data/adas/adas_to_numpy.py
+python ../gyrokinetic/data/adas/process_adas.py
 rm *.dat
 cp *.npy $ADAS_DIR/adas/.
 mv *.npy ../gyrokinetic/data/adas/.

--- a/install-deps/mkdeps.sh
+++ b/install-deps/mkdeps.sh
@@ -58,7 +58,7 @@ The following flags specify the libraries to build.
 --build-openmpi             [no] Should we build OpenMPI?
 --build-luajit              [no] Should we build LuaJIT?
 --build-cudss               [no] Should we build cuDSS?
---build-adas                [no] Should we download ADAS data? (uses python, needs the `requests, os, shutil, sys` modules)
+--build-adas                [no] Should we download ADAS data? (uses python, needs numpy)
 
 EOF
 }

--- a/install-deps/mkdeps.sh
+++ b/install-deps/mkdeps.sh
@@ -58,6 +58,7 @@ The following flags specify the libraries to build.
 --build-openmpi             [no] Should we build OpenMPI?
 --build-luajit              [no] Should we build LuaJIT?
 --build-cudss               [no] Should we build cuDSS?
+--build-adas                [no] Should we download ADAS data? (uses python, needs the `requests, os, shutil, sys` modules)
 
 EOF
 }
@@ -166,6 +167,10 @@ do
       [ -n "$value" ] || die "Missing value in flag $key."
       BUILD_CUDSS="$value"
       ;;   
+   --build-adas)
+      [ -n "$value" ] || die "Missing value in flag $key."
+      BUILD_ADAS="$value"
+      ;;
    *)
       die "Error: Unknown flag: $1"
       ;;
@@ -253,6 +258,14 @@ build_cudss() {
     fi
 }
 
+build_adas() {
+    if [ "$BUILD_ADAS" = "yes" ]
+    then
+	echo "Downloading ADAS data for neutral reactions"
+	./download-adas.sh
+    fi
+}
+
 echo "Installations will be in  $PREFIX"
 
 build_openmpi
@@ -261,3 +274,4 @@ build_openblas
 build_superlu
 build_superlu_dist
 build_cudss
+build_adas

--- a/machines/configure.stellar-intel.sh
+++ b/machines/configure.stellar-intel.sh
@@ -2,5 +2,5 @@ module load intel/2021.1.2
 module load openmpi/intel-2021.1/4.1.2 
 
 : "${PREFIX:=$HOME/gkylsoft}"
-./configure CC=cc --prefix=$PREFIX --use-mpi=yes --mpi-inc=$MPI_HOME/include --mpi-lib=$MPI_HOME/lib64 --use-adas=yes --use-lua=yes
+./configure CC=cc --prefix=$PREFIX --use-mpi=yes --mpi-inc=$MPI_HOME/include --mpi-lib=$MPI_HOME/lib64 --use-lua=yes
 


### PR DESCRIPTION
see commit message.

Also: @tnbernard 's previous PR had also made it so that if the needed python modules are not detected, it downloads them. I've deleted that also because it would pollute the user's environment without them knowing it. For now we are basically reverting to the previous state of affairs, where the user must have installed the python modules themselves (and they are mentioned in the description of the --build-adas flag in mkdeps)