### PR TITLE
gk app GPU build fix: move GKYL_SHARE_DIR definition in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,10 +32,6 @@ PROJ_NAME ?= gkeyll
 # Determine OS we are running on
 UNAME = $(shell uname)
 
-# Directory for storing shared data, like ADAS reaction rates and radiation fits
-GKYL_SHARE_DIR ?= "${INSTALL_PREFIX}/${PROJ_NAME}/share"
-CFLAGS += -DGKYL_SHARE_DIR=\"$(GKYL_SHARE_DIR)\"
-
 # On OSX we should use Accelerate framework
 ifeq ($(UNAME), Darwin)
 	LAPACK_LIB_DIR = .
@@ -61,6 +57,10 @@ ifeq ($(CC), nvcc)
 	CUDA_LIBS += -lcublas -lcusparse -lcusolver
 	SQL_CFLAGS = --forward-unknown-to-host-compiler -fPIC
 endif
+
+# Directory for storing shared data, like ADAS reaction rates and radiation fits
+GKYL_SHARE_DIR ?= "${INSTALL_PREFIX}/${PROJ_NAME}/share"
+CFLAGS += -DGKYL_SHARE_DIR=\"$(GKYL_SHARE_DIR)\"
 
 # MPI paths and flags
 USING_MPI =


### PR DESCRIPTION
#### Problem
The gk app could not be built on GPU anymore (test on Perlmutter).
#### Cause 
The Makefile defines and adds the `GKYL_SHARE_DIR` variable before a reset of the CFLAGS when building for GPU, see
https://github.com/ammarhakim/gkeyll/blob/479e175d387ca03588a059c736b4633aff312430/Makefile#L37

#### Solution
Moving this paragraph to after the GPU build check `ifeq ($(CC), nvcc)` paragraph resolves it and I don't think it causes any problem to put it there as `GKYL_SHARE_DIR` isn't used anywhere else.

One could also consider moving each `CFLAGS+=` statement after the GPU build check to be sure that it is not overwritten.