### PR TITLE
Pitagora config files

### DIFF
--- a/machines/configure.pitagora-gpu.sh
+++ b/machines/configure.pitagora-gpu.sh
@@ -1,4 +1,4 @@
-# Trying the only available version of cuda, openmpi, nccl in pitagora
+# Loading modules, pitagora currently only supports cuda 12.6
 
 module load cuda/12.6
 module load openmpi/4.1.6--gcc--12.3.0

--- a/machines/configure.pitagora-gpu.sh
+++ b/machines/configure.pitagora-gpu.sh
@@ -1,0 +1,10 @@
+# Trying the only available version of cuda, openmpi, nccl in pitagora
+
+module load cuda/12.6
+module load openmpi/4.1.6--gcc--12.3.0
+module load nccl/2.22.3-1--gcc--12.3.0
+module load cmake/3.27.9
+
+: "${PREFIX:=$HOME/gkylsoft}"
+
+./configure CC=nvcc ARCH_FLAGS="-march=native" CUDA_ARCH=90 --prefix=$PREFIX --lapack-inc=$PREFIX/OpenBLAS/include --lapack-lib=$PREFIX/OpenBLAS/lib/libopenblas.a --superlu-inc=$PREFIX/superlu/include --superlu-lib=$PREFIX/superlu/lib/libsuperlu.a --use-mpi=yes --mpi-inc=$OPENMPI_HOME/include --mpi-lib=$OPENMPI_HOME/lib --use-nccl=yes --nccl-inc=$NCCL_HOME/include --nccl-lib=$NCCL_HOME/lib --use-lua=yes --use-cudss=yes;

--- a/machines/mkdeps.pitagora-gpu.sh
+++ b/machines/mkdeps.pitagora-gpu.sh
@@ -1,4 +1,4 @@
-# available versions of cuda bla bla in pitagora need to check if these work
+# Loading modules, pitagora currently only supports cuda 12.6 
 
 module load cuda/12.6
 module load module load openmpi/4.1.6--gcc--12.3.0

--- a/machines/mkdeps.pitagora-gpu.sh
+++ b/machines/mkdeps.pitagora-gpu.sh
@@ -1,0 +1,10 @@
+# available versions of cuda bla bla in pitagora need to check if these work
+
+module load cuda/12.6
+module load module load openmpi/4.1.6--gcc--12.3.0
+module load nccl/2.22.3-1--gcc--12.3.0
+module load cmake/3.27.9
+
+cd install-deps
+: "${PREFIX:=$HOME/gkylsoft}"
+./mkdeps.sh --build-openblas=yes --build-superlu=yes --build-luajit=yes --build-cudss=yes --build-adas=yes --prefix=$PREFIX


### PR DESCRIPTION
Add mkdeps and configure files for successfully installing Gkeyll in Pitagora, the Eurofusion supercomputer. 