### PR TITLE
Switch skin_ghost_ranges from global to local

### DIFF
--- a/moments/apps/moment.c
+++ b/moments/apps/moment.c
@@ -124,7 +124,7 @@ gkyl_moment_app_new(struct gkyl_moment *mom)
     gkyl_create_ranges(&app->decomp->ranges[rank], ghost, &app->local_ext, &app->local);
   }
 
-  skin_ghost_ranges_init(&app->skin_ghost, &app->global_ext, ghost);  
+  skin_ghost_ranges_init(&app->skin_ghost, &app->local_ext, ghost);  
   
   app->c2p_ctx = app->mapc2p = 0;  
   app->has_mapc2p = mom->mapc2p ? true : false;


### PR DESCRIPTION
This PR switches skin_ghost_ranges from global to local, which fixes a segfault issue for running wedge BCs in parallel