### PR TITLE
Small fix to the CFL diagnostic name

### DIFF
--- a/gyrokinetic/apps/gk_species.c
+++ b/gyrokinetic/apps/gk_species.c
@@ -419,7 +419,7 @@ gk_species_write_cfl_enabled(gkyl_gyrokinetic_app* app, struct gk_species *gks, 
     }
   );
 
-  const char *fmt = "%s-%s-cflrate_%d.gkyl";
+  const char *fmt = "%s-%s_cflrate_%d.gkyl";
   int sz = gkyl_calc_strlen(fmt, app->name, gks->info.name, frame);
   char fileNm[sz+1]; // ensures no buffer overflow
   snprintf(fileNm, sizeof fileNm, fmt, app->name, gks->info.name, frame);


### PR DESCRIPTION
The diagnostic had a dash where there should have been an underscore