### PR TITLE
Added warning for headerless eqdsk files

### DIFF
--- a/gyrokinetic/zero/efit.c
+++ b/gyrokinetic/zero/efit.c
@@ -41,7 +41,13 @@ gkyl_efit* gkyl_efit_new(const struct gkyl_efit_inp *inp)
   char header[49];   // case in eqdsk header
   int idum; // idum in eqdsk header
   status = fscanf(ptr, "%48c%4d%4d%4d", header, &idum, &up->nr, &up->nz);
-
+  
+  // If the first 48 characters of the eqdsk file contain a newline, then the EQDSK file lacks a header.
+  if(strchr(header,'\n')!=NULL)
+  {
+      fprintf(stderr, "Warning: %s likely lacks a header on the first line and may not be parsed correctly. Parsed dimensions are (nr=%s,nz=%s)\n", up->filepath, up->nr, up->nz);
+  }
+  
   // Read the non-array parameters, all are doubles:
   // rdim,zdim,rcentr,rleft,zmid;
   // rmaxis,zmaxis,simag,sibry,bcentr;


### PR DESCRIPTION
In https://github.com/ammarhakim/gkeyll/commit/c2d8c56907afeb7c6922aff7790577d771cef348 a change was made to the eqdsk parser so that it now reads the header, removing the need to manually remove the header from the eqdsk. However, if an eqdsk file used in previous gkeyll simulations (with the header removed) is used, this causes errors: The parser assumes the first 48 characters of the file are the header, and then attempts to read the `nr` and `nz` values from the `rdim`, `zdim` etc. block. This will generally cause cryptic error messages that can be difficult to debug for the end user unaware of these changes to the parser.

This change checks if the first 48 characters contain a newline character, which is a sign the header has been removed, and gives the user a warning if this is the case.