### PR TITLE
compute-sanitizer is not clean for gk reg test (communicator release fails)

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,8 +369,16 @@ on CPUs with e.g.
 valgrind --leak-check=full <executable> <command_line_arguments>
 ```
 
-and compute-sanitizer clean on GPUs with e.g.
+and compute-sanitizer clean on one GPU with e.g.
 
 ```
-compute-sanitizer --tool memcheck <executable> <command_line_arguments>
+compute-sanitizer --tool memcheck --leak-check full <executable> <command_line_arguments>
 ```
+
+To check using multiple GPUs on a Perlmuttter node with SLURM e.g.
+
+```
+srun -N 1 --ntasks=2 --gpus-per-task=1 --gpu-bind=closest compute-sanitizer --tool memcheck --leak-check full <executable> <command_line_arguments>
+```
+
+where the command line arguments must at least contain `-g -M -direction 2` with `direction` being the direction along which the domain is decomposed, e.g. `-e 2` for 3x2v gk simulations.

--- a/core/zero/nccl_comm.c
+++ b/core/zero/nccl_comm.c
@@ -96,23 +96,21 @@ comm_free(const struct gkyl_ref_count *ref)
   struct gkyl_comm *comm = container_of(ref, struct gkyl_comm, ref_count);
   struct nccl_comm *nccl = container_of(comm, struct nccl_comm, priv_comm.pub_comm);
 
-  if (nccl->has_decomp) {
-    int ndim = nccl->decomp->ndim;
-    gkyl_rect_decomp_release(nccl->decomp);
+  int ndim = nccl->decomp->ndim;
+  gkyl_rect_decomp_release(nccl->decomp);
 
-    gkyl_rect_decomp_neigh_release(nccl->neigh);
-    for (int d=0; d<ndim; ++d)
-      gkyl_rect_decomp_neigh_release(nccl->per_neigh[d]);
+  gkyl_rect_decomp_neigh_release(nccl->neigh);
+  for (int d=0; d<ndim; ++d)
+    gkyl_rect_decomp_neigh_release(nccl->per_neigh[d]);
 
-    for (int i=0; i<MAX_RECV_NEIGH; ++i)
-      gkyl_mem_buff_release(nccl->recv[i].buff);
+  for (int i=0; i<MAX_RECV_NEIGH; ++i)
+    gkyl_mem_buff_release(nccl->recv[i].buff);
 
-    for (int i=0; i<MAX_RECV_NEIGH; ++i)
-      gkyl_mem_buff_release(nccl->send[i].buff);
+  for (int i=0; i<MAX_RECV_NEIGH; ++i)
+    gkyl_mem_buff_release(nccl->send[i].buff);
 
-    gkyl_mem_buff_release(nccl->allgather_buff_local.buff);
-    gkyl_mem_buff_release(nccl->allgather_buff_global.buff);
-  }
+  gkyl_mem_buff_release(nccl->allgather_buff_local.buff);
+  gkyl_mem_buff_release(nccl->allgather_buff_global.buff);
 
   // Finalize NCCL comm.
   checkCuda(cudaStreamSynchronize(nccl->custream));
@@ -625,7 +623,6 @@ nccl_comm_new(const struct gkyl_nccl_comm_inp *inp,
   struct nccl_comm *nccl = gkyl_malloc(sizeof *nccl);
   strcpy(nccl->priv_comm.pub_comm.id, "nccl_comm");
   
-  nccl->has_decomp = false; // will be set to true if decomp is provided
   nccl->is_mcomm_allocated = extra_inp->is_comm_allocated;
   nccl->mcomm = inp->mpi_comm;
 
@@ -681,7 +678,6 @@ nccl_comm_new(const struct gkyl_nccl_comm_inp *inp,
   else {
     nccl->decomp = gkyl_rect_decomp_acquire(inp->decomp);
   }
-  nccl->has_decomp = true;
 
   nccl->neigh = gkyl_rect_decomp_calc_neigh(nccl->decomp, inp->sync_corners, nccl->rank);
   for (int d=0; d<nccl->decomp->ndim; ++d)

--- a/core/zero/nccl_comm.c
+++ b/core/zero/nccl_comm.c
@@ -625,6 +625,7 @@ nccl_comm_new(const struct gkyl_nccl_comm_inp *inp,
   struct nccl_comm *nccl = gkyl_malloc(sizeof *nccl);
   strcpy(nccl->priv_comm.pub_comm.id, "nccl_comm");
   
+  nccl->has_decomp = false; // will be set to true if decomp is provided
   nccl->is_mcomm_allocated = extra_inp->is_comm_allocated;
   nccl->mcomm = inp->mpi_comm;
 
@@ -680,6 +681,7 @@ nccl_comm_new(const struct gkyl_nccl_comm_inp *inp,
   else {
     nccl->decomp = gkyl_rect_decomp_acquire(inp->decomp);
   }
+  nccl->has_decomp = true;
 
   nccl->neigh = gkyl_rect_decomp_calc_neigh(nccl->decomp, inp->sync_corners, nccl->rank);
   for (int d=0; d<nccl->decomp->ndim; ++d)

--- a/gyrokinetic/creg/rt_gk_tcv_iwl_adapt_source_3x2v_p1.c
+++ b/gyrokinetic/creg/rt_gk_tcv_iwl_adapt_source_3x2v_p1.c
@@ -435,7 +435,7 @@ struct gk_app_ctx create_ctx(void)
   double z_max     =  Lz/2.;
 
   // Collision frequencies
-  double nuFrac = 0.5;
+  double nuFrac = 0.1;
   // Electron-electron collision freq.
   double logLambdaElc = 6.6 - 0.5 * log(n0/1e20) + 1.5 * log(Ti0/eV);
   double nuElc = nuFrac * logLambdaElc * pow(eV, 4) * n0 /
@@ -468,19 +468,19 @@ struct gk_app_ctx create_ctx(void)
   double sigma_srcRECY[3] = {0.25*x_LCFS, 0.0, 0.05*Lz};
   double floor_srcRECY = 1e-10;
 
-  // Grid parameters
-  int num_cell_x = 9; // The LCFS is positionned at 1/3 of the domain -> the resolution must be divisible by 3.
-  int num_cell_y = 6;
-  int num_cell_z = 6;
-  int num_cell_vpar = 6;
-  int num_cell_mu = 4;
+  // Grid parameters (reduced resolution for the regression test, minimal recommended values in comments)
+  int num_cell_x = 9; // (24) The LCFS is positionned at 1/3 of the domain -> the resolution must be divisible by 3.
+  int num_cell_y = 8; // (16)
+  int num_cell_z = 8; // (12)
+  int num_cell_vpar = 8; // (12)
+  int num_cell_mu = 8; // (8)
   int poly_order = 1;
   // Velocity box dimensions
   double vpar_max_elc = 5.*vte;
   double mu_max_elc   = 1.*me*pow(4*vte,2)/(2*B0);
   double vpar_max_ion = 5.*vti;
   double mu_max_ion   = 1.*mi*pow(4*vti,2)/(2*B0);
-  double final_time = 1.e-6;
+  double final_time = 1.e-7; // Should be reached in 13 steps
   int num_frames = 1;
   double write_phase_freq = 1.0;
   int int_diag_calc_num = num_frames*100;


### PR DESCRIPTION
After running on perlmutter
```bash
srun -N 1 --ntasks=2 --gpus-per-task=1 --gpu-bind=closest compute-sanitizer --tool memcheck --leak-check full ./gkeyll_exec -M -g -e 2 -s 10 | tee memcheck_test.log
```
I discovered that the regression tests rt_gk_tcv_iwl_adapt_source_3x2v_p1 and rt_gk_tcv_sheath_3x2v_p1 are not compute-sanitizer clean. This leak is just due to a failure in releasing the communicator because the `nccl->has_deomp` is not always initialized. This branch fixes it.

Here is the kind of leak error that was popping :
```bash
========= Leaked 248,832 bytes at 0x7f78f1a00000
=========     Saved host backtrace up to driver entry point at allocation time
=========     Host Frame: [0x29220e]
=========                in /usr/lib64/libcuda.so.1
=========     Host Frame:libcudart_static_5382377d5c772c9d197c0cda9fd9742ee6ad893c [0x5d0723d]
=========                in /global/homes/a/ah1032/gkeyll_main/gkylsoft/gkeyll/lib/libg0pkpm.so
=========     Host Frame:libcudart_static_5382377d5c772c9d197c0cda9fd9742ee6ad893c [0x5d0723d]
=========                in /global/homes/a/ah1032/gkeyll_main/gkylsoft/gkeyll/lib/libg0pkpm.so
=========     Host Frame:libcudart_static_f74e2f2bcf2cf49bd1a61332e1d15bd1e748f9cf [0x5cd1ec2]
=========                in /global/homes/a/ah1032/gkeyll_main/gkylsoft/gkeyll/lib/libg0pkpm.so
=========     Host Frame:libcudart_static_f74e2f2bcf2cf49bd1a61332e1d15bd1e748f9cf [0x5cd1ec2]
=========                in /global/homes/a/ah1032/gkeyll_main/gkylsoft/gkeyll/lib/libg0pkpm.so
=========     Host Frame:cudaMalloc [0x5d16794]
=========                in /global/homes/a/ah1032/gkeyll_main/gkylsoft/gkeyll/lib/libg0pkpm.so
=========     Host Frame:cudaMalloc [0x5d16794]
=========                in /global/homes/a/ah1032/gkeyll_main/gkylsoft/gkeyll/lib/libg0pkpm.so
=========     Host Frame:gkyl_cu_malloc_ in zero/alloc.c:201 [0x902a7d]
=========                in /global/homes/a/ah1032/gkeyll_main/gkylsoft/gkeyll/lib/libg0pkpm.so
=========     Host Frame:gkyl_cu_malloc_ in zero/alloc.c:201 [0x902a7d]
=========                in /global/homes/a/ah1032/gkeyll_main/gkylsoft/gkeyll/lib/libg0pkpm.so
=========     Host Frame:gkyl_mem_buff_resize in zero/alloc.c:155 [0x902db0]
=========                in /global/homes/a/ah1032/gkeyll_main/gkylsoft/gkeyll/lib/libg0pkpm.so
=========     Host Frame:gkyl_mem_buff_resize in zero/alloc.c:155 [0x902db0]
=========                in /global/homes/a/ah1032/gkeyll_main/gkylsoft/gkeyll/lib/libg0pkpm.so
=========     Host Frame:array_per_sync.part.0 in zero/nccl_comm.c:463 [0x95e7b0]
=========                in /global/homes/a/ah1032/gkeyll_main/gkylsoft/gkeyll/lib/libg0pkpm.so
=========     Host Frame:array_per_sync.part.0 in zero/nccl_comm.c:463 [0x95e7b0]
=========                in /global/homes/a/ah1032/gkeyll_main/gkylsoft/gkeyll/lib/libg0pkpm.so
=========     Host Frame:array_per_sync in zero/nccl_comm.c:423 [0x95e931]
=========                in /global/homes/a/ah1032/gkeyll_main/gkylsoft/gkeyll/lib/libg0pkpm.so
=========     Host Frame:array_per_sync in zero/nccl_comm.c:423 [0x95e931]
=========                in /global/homes/a/ah1032/gkeyll_main/gkylsoft/gkeyll/lib/libg0pkpm.so
=========     Host Frame:gk_species_apply_bc_dynamic in apps/gk_species.c:237 [0x4ee5c34]
=========                in /global/homes/a/ah1032/gkeyll_main/gkylsoft/gkeyll/lib/libg0pkpm.so
=========     Host Frame:gk_species_apply_bc_dynamic in apps/gk_species.c:237 [0x4ee5c34]
=========                in /global/homes/a/ah1032/gkeyll_main/gkylsoft/gkeyll/lib/libg0pkpm.so
=========     Host Frame:gkyl_gyrokinetic_app_apply_ic in apps/gyrokinetic.c:916 [0x4efcd5f]
=========                in /global/homes/a/ah1032/gkeyll_main/gkylsoft/gkeyll/lib/libg0pkpm.so
=========     Host Frame:gkyl_gyrokinetic_app_apply_ic in apps/gyrokinetic.c:916 [0x4efcd5f]
=========                in /global/homes/a/ah1032/gkeyll_main/gkylsoft/gkeyll/lib/libg0pkpm.so
=========     Host Frame:main in /global/homes/a/ah1032/gkeyll_main/gkeyll/rt_gk_tcv_iwl_adapt_source_3x2v_p1.o/rt_gk_tcv_iwl_adapt_source_3x2v_p1.c:892 [0x30b2]
=========                in /global/u1/a/ah1032/gkeyll_main/gkeyll/rt_gk_tcv_iwl_adapt_source_3x2v_p1.o/./rt_gk_tcv_iwl_adapt_source_3x2v_p1
=========     Host Frame:__libc_start_main [0x351fc]
=========                in /lib64/libc.so.6
=========     Host Frame:_start in ../sysdeps/x86_64/start.S:120 [0x3909]
=========                in /global/u1/a/ah1032/gkeyll_main/gkeyll/rt_gk_tcv_iwl_adapt_source_3x2v_p1.o/./rt_gk_tcv_iwl_adapt_source_3x2v_p1
========= 
=========     Host Frame:main in /global/homes/a/ah1032/gkeyll_main/gkeyll/rt_gk_tcv_iwl_adapt_source_3x2v_p1.o/rt_gk_tcv_iwl_adapt_source_3x2v_p1.c:892 [0x30b2]
=========                in /global/u1/a/ah1032/gkeyll_main/gkeyll/rt_gk_tcv_iwl_adapt_source_3x2v_p1.o/./rt_gk_tcv_iwl_adapt_source_3x2v_p1
=========     Host Frame:__libc_start_main [0x351fc]
=========                in /lib64/libc.so.6
=========     Host Frame:_start in ../sysdeps/x86_64/start.S:120 [0x3909]
=========                in /global/u1/a/ah1032/gkeyll_main/gkeyll/rt_gk_tcv_iwl_adapt_source_3x2v_p1.o/./rt_gk_tcv_iwl_adapt_source_3x2v_p1
========= 
```