### PR TITLE
The q-profile cubic fit coefficients got reversed in the TCV regression tests.

### DIFF
--- a/gyrokinetic/creg/rt_gk_tcv_iwl_adapt_source_2x2v_p1.c
+++ b/gyrokinetic/creg/rt_gk_tcv_iwl_adapt_source_2x2v_p1.c
@@ -51,9 +51,10 @@ double r_x(double x, double a_mid, double x_inner)
 // cubic polynomial fit to TCV NT q profile (discharge #65130)
 double qprofile(double r, double R_axis) {
   double R = r + R_axis;
-  double qfit[4] = {484.0615913225881, -1378.25993228584, 
-                    1309.3099150729233, -414.13270311478726};
-  return qfit[0] + qfit[1]*R + qfit[2]*R*R + qfit[3]*R*R*R;
+  double qfit[4] = {
+    -414.13270311478726, 1309.3099150729233, -1378.25993228584, 484.0615913225881
+  };
+  return qfit[3]*R*R*R + qfit[2]*R*R + qfit[1]*R + qfit[0];
 }
 
 double R_rtheta(double r, double theta, void *ctx)

--- a/gyrokinetic/creg/rt_gk_tcv_iwl_adapt_source_3x2v_p1.c
+++ b/gyrokinetic/creg/rt_gk_tcv_iwl_adapt_source_3x2v_p1.c
@@ -52,9 +52,10 @@ double r_x(double x, double a_mid, double x_inner)
 // cubic polynomial fit to TCV NT q profile (discharge #65130)
 double qprofile(double r, double R_axis) {
   double R = r + R_axis;
-  double qfit[4] = {484.0615913225881, -1378.25993228584, 
-                    1309.3099150729233, -414.13270311478726};
-  return qfit[0] + qfit[1]*R + qfit[2]*R*R + qfit[3]*R*R*R;
+  double qfit[4] = {
+    -414.13270311478726, 1309.3099150729233, -1378.25993228584, 484.0615913225881
+  };
+  return qfit[3]*R*R*R + qfit[2]*R*R + qfit[1]*R + qfit[0];
 }
 
 double R_rtheta(double r, double theta, void *ctx)


### PR DESCRIPTION
This happened when we put back the cubic fit instead of the piecewise linear ones during the tsbc_fix branch merge.