### PR TITLE
1x Fromfile Fix

### DIFF
--- a/core/zero/nodal_ops.c
+++ b/core/zero/nodal_ops.c
@@ -208,11 +208,61 @@ gkyl_nodal_ops_n2m_surface(const struct gkyl_nodal_ops *nodal_ops,
 }
 
 void 
+gkyl_nodal_ops_m2n_surface_1x(const struct gkyl_nodal_ops *nodal_ops, 
+  const struct gkyl_rect_grid *grid, 
+  const struct gkyl_range *nrange, const struct gkyl_range *update_range, int num_comp, 
+  struct gkyl_array *nodal_fld, const struct gkyl_array *modal_fld, int dir) 
+{
+
+  int num_basis = 1;
+  double fnodal[num_basis]; // to store nodal function values
+
+  struct gkyl_range_iter iter;
+  gkyl_range_iter_init(&iter, update_range);
+  int nidx[3];
+  long lin_nidx[num_basis];
+  
+  while (gkyl_range_iter_next(&iter)) {
+    for (int i=0; i<num_basis; ++i) {
+      const double *temp  = gkyl_array_cfetch(nodal_ops->nodes,i);
+      for( int j = 0; j < grid->ndim; j++) {
+        nidx[j] = (iter.idx[j]-update_range->lower[j]) ;
+      }
+      lin_nidx[i] = gkyl_range_idx(nrange, nidx);
+    }
+
+    long lidx = gkyl_range_idx(update_range, iter.idx);
+    const double *arr_p = gkyl_array_cfetch(modal_fld, lidx);
+    double fao[num_basis*num_comp];
+
+    for (int i=0; i<num_comp; ++i) {
+      // transform to modal expansion
+      for (int k=0; k<num_basis; ++k){
+        fnodal[k] = arr_p[num_basis*i];
+      }
+      // copy so nodal values for each return value are contiguous
+      // (recall that function can have more than one return value)
+      for (int k=0; k<num_basis; ++k)
+        fao[num_comp*k+i] = fnodal[k];
+    }
+
+    for (int i=0; i<num_basis; ++i) {
+      double *temp = gkyl_array_fetch(nodal_fld, lin_nidx[i]);
+      for (int j=0; j<num_comp; ++j) {
+         temp[j] = fao[i*num_comp + j];
+      }
+    }
+   }
+}
+
+void 
 gkyl_nodal_ops_m2n_surface(const struct gkyl_nodal_ops *nodal_ops, 
   const struct gkyl_basis *cbasis, const struct gkyl_rect_grid *grid, 
   const struct gkyl_range *nrange, const struct gkyl_range *update_range, int num_comp, 
   struct gkyl_array *nodal_fld, const struct gkyl_array *modal_fld, int dir) 
 {
+  if(grid->ndim==1)
+    return gkyl_nodal_ops_m2n_surface_1x(nodal_ops, grid, nrange, update_range, num_comp, nodal_fld, modal_fld, dir);
 
   int num_basis = cbasis->num_basis;
   int cpoly_order = cbasis->poly_order;

--- a/core/zero/nodal_ops.c
+++ b/core/zero/nodal_ops.c
@@ -140,11 +140,61 @@ gkyl_nodal_ops_n2m_interior(const struct gkyl_nodal_ops *nodal_ops,
 }
 
 void 
+gkyl_nodal_ops_n2m_surface_1x(const struct gkyl_nodal_ops *nodal_ops, 
+  const struct gkyl_rect_grid *grid, 
+  const struct gkyl_range *nrange, const struct gkyl_range *update_range, int num_comp, 
+  const struct gkyl_array *nodal_fld, struct gkyl_array *modal_fld, int dir) 
+{
+
+  int num_basis = 1;
+  double fnodal[num_basis]; // to store nodal function values
+
+  struct gkyl_range_iter iter;
+  gkyl_range_iter_init(&iter, update_range);
+  int nidx[3];
+  long lin_nidx[num_basis];
+  
+  while (gkyl_range_iter_next(&iter)) {
+    for (int i=0; i<num_basis; ++i) {
+      const double *temp  = gkyl_array_cfetch(nodal_ops->nodes,i);
+      for( int j = 0; j < grid->ndim; j++) {
+        nidx[j] = (iter.idx[j]-update_range->lower[j]) ;
+      }
+      lin_nidx[i] = gkyl_range_idx(nrange, nidx);
+    }
+
+    long lidx = gkyl_range_idx(update_range, iter.idx);
+    double *arr_p = gkyl_array_fetch(modal_fld, lidx);
+    double fao[num_basis*num_comp];
+  
+    for (int i=0; i<num_basis; ++i) {
+      const double *temp = gkyl_array_cfetch(nodal_fld, lin_nidx[i]);
+      for (int j=0; j<num_comp; ++j) {
+        fao[i*num_comp + j] = temp[j];
+      }
+    }
+
+    for (int i=0; i<num_comp; ++i) {
+      // copy so nodal values for each return value are contiguous
+      // (recall that function can have more than one return value)
+      for (int k=0; k<num_basis; ++k) {
+        fnodal[k] = fao[num_comp*k+i];
+      }
+      // transform to modal expansion
+      for (int k=0; k<num_basis; ++k)
+        arr_p[num_basis*i] = fnodal[k];
+    }
+  }
+}
+
+void 
 gkyl_nodal_ops_n2m_surface(const struct gkyl_nodal_ops *nodal_ops, 
   const struct gkyl_basis *cbasis, const struct gkyl_rect_grid *grid, 
   const struct gkyl_range *nrange, const struct gkyl_range *update_range, int num_comp, 
   const struct gkyl_array *nodal_fld, struct gkyl_array *modal_fld, int dir) 
 {
+  if(grid->ndim==1)
+    return gkyl_nodal_ops_n2m_surface_1x(nodal_ops, grid, nrange, update_range, num_comp, nodal_fld, modal_fld, dir);
 
   int num_basis = cbasis->num_basis;
   int cpoly_order = cbasis->poly_order;


### PR DESCRIPTION
Addresses the bug in issue #839 . Thanks to @manauref for catching this.

modal to nodal and nodal to modal operations on surfaces are different for 1x simulations since there is no 0d basis. This commit addresses the issue and makes geometry fromfile work correctly for 1x. Below is the final potential from the gk_sheath_1x2v regression test run normally with mapc2p geometry and then with geometry fromfile. 
<img width="630" height="467" alt="image" src="https://github.com/user-attachments/assets/f38d99b2-95de-461b-866f-dffc61619f8d" />
