### PR TITLE
Micro fix of a CPU warning: hardcoded variable for an array size

### DIFF
--- a/gyrokinetic/zero/rescale_ghost_jacf.c
+++ b/gyrokinetic/zero/rescale_ghost_jacf.c
@@ -53,8 +53,6 @@ gkyl_rescale_ghost_jacf_advance(const struct gkyl_rescale_ghost_jacf *up,
   int rem_dir[GKYL_MAX_DIM] = {0};
   for (int d=0; d<cdim; ++d) rem_dir[d] = 1;
 
-  const int num_basis_conf_surf = 8; // MF 2024/11/12: Hardcoded to 2x p2 for now.
-  const int num_basis_phase_surf = 24; // MF 2024/11/12: Hardcoded to 2x2v GkHybrid for now.
  
   gkyl_range_iter_init(&conf_iter, conf_ghost_r);
   while (gkyl_range_iter_next(&conf_iter)) {
@@ -70,7 +68,7 @@ gkyl_rescale_ghost_jacf_advance(const struct gkyl_rescale_ghost_jacf *up,
     const double *jacghost_surf_c = gkyl_array_cfetch(jac_sync, clinidx_ghost);
 
     // Compute the reciprocal of the ghost cell jacobian.
-    double jacghost_surf_inv_c[num_basis_conf_surf];
+    double jacghost_surf_inv_c[8]; // MF 2024/11/12: Hardcoded to 2x p2 for now.
     up->kernels->conf_inv_op(jacghost_surf_c, jacghost_surf_inv_c);
 
     gkyl_range_deflate(&vel_rng, phase_ghost_r, rem_dir, conf_iter.idx);
@@ -80,7 +78,7 @@ gkyl_rescale_ghost_jacf_advance(const struct gkyl_rescale_ghost_jacf *up,
       double *jf_c = gkyl_array_fetch(jf, plinidx_ghost);
 
       // Deflate Jf in the ghost cell.
-      double jf_surf_c[num_basis_phase_surf];
+      double jf_surf_c[24]; // MF 2024/11/12: Hardcoded to 2x2v GkHybrid for now.
       up->kernels->deflate_phase_ghost_op(jf_c, jf_surf_c);
 
       // Multiply the surface Jf by the surface 1/J_ghost and by the surface J_skin.

--- a/gyrokinetic/zero/rescale_ghost_jacf_cu.cu
+++ b/gyrokinetic/zero/rescale_ghost_jacf_cu.cu
@@ -70,9 +70,6 @@ gkyl_rescale_ghost_jacf_advance_cu_ker(struct gkyl_rescale_ghost_jacf_kernels *k
 
   int cdim = conf_skin_r.ndim;
 
-  const int num_basis_conf_surf = 8; // MF 2024/11/12: Hardcoded to 2x p2 for now.
-  const int num_basis_phase_surf = 24; // MF 2024/11/12: Hardcoded to 2x2v GkHybrid for now.
-
   // Loop over all points in the skin range using CUDA threads.
   for (unsigned long linc = threadIdx.x + blockIdx.x * blockDim.x;
        linc < phase_ghost_r.volume; linc += blockDim.x * gridDim.x) {
@@ -92,14 +89,14 @@ gkyl_rescale_ghost_jacf_advance_cu_ker(struct gkyl_rescale_ghost_jacf_kernels *k
     const double *jacghost_surf_c = (const double *) gkyl_array_cfetch(jac_sync, clinidx_ghost);
 
     // Compute the reciprocal of the ghost cell jacobian.
-    double jacghost_surf_inv_c[num_basis_conf_surf];
+    double jacghost_surf_inv_c[8]; // MF 2024/11/12: Hardcoded to 2x p2 for now.
     kers->conf_inv_op(jacghost_surf_c, jacghost_surf_inv_c);
 
     long plinidx_ghost = gkyl_range_idx(&phase_ghost_r, gidx);
     double *jf_c = (double *) gkyl_array_fetch(jf, plinidx_ghost);
 
     // Deflate Jf in the ghost cell.
-    double jf_surf_c[num_basis_phase_surf];
+    double jf_surf_c[24]; // MF 2024/11/12: Hardcoded to 2x2v GkHybrid for now.
     kers->deflate_phase_ghost_op(jf_c, jf_surf_c);
 
     // Multiply the surface Jf by the surface 1/J_ghost and by the surface J_skin.


### PR DESCRIPTION
This is a micro fix of a warning occuring because the CPU compiler does not like to use a variable (even if the value is hardcoded) to initialize the size of an array.

the warnings are:
```bash
zero/rescale_ghost_jacf.c:73:32: warning: variable length array folded to constant array as an extension [-Wgnu-folding-constant]
   73 |     double jacghost_surf_inv_c[num_basis_conf_surf];
      |                                ^~~~~~~~~~~~~~~~~~~
zero/rescale_ghost_jacf.c:83:24: warning: variable length array folded to constant array as an extension [-Wgnu-folding-constant]
   83 |       double jf_surf_c[num_basis_phase_surf];
      |                        ^~~~~~~~~~~~~~~~~~~~
```

This PR simply put the hardcoded values directly in the array definitions instead of declaring it above through a variable. Also I think that it is better since we see now directly at the line that the array have hardcoded size.

BTW there is still this other warning:
```bash
apps/mom_species.c:460:23: warning: comparison of different enumeration types ('enum gkyl_eqn_type' and 'enum gkyl_wv_mhd_div_constraint') [-Wenum-compare]
  460 |       if (sp->eqn_type==GKYL_MHD_DIVB_GLM) {
      |           ~~~~~~~~~~~~^ ~~~~~~~~~~~~~~~~~
``` 
which I think requires a deeper fix.